### PR TITLE
Add `focus-visible-within` for `group` (parent) and `peer` (sibling)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
-const plugin = require('tailwindcss/plugin');
+const plugin = require("tailwindcss/plugin");
 
 module.exports = plugin(function ({addVariant}) {
-    addVariant('focus-visible-within', ['&:has(:focus-visible)'])
+    addVariant("focus-visible-within", ["&:has(:focus-visible)"]);
+    addVariant("group-focus-visible-within", ":merge(.group):has(:focus-visible) &");
+    addVariant("peer-focus-visible-within", ":merge(.peer):has(:focus-visible) ~ &");
 });


### PR DESCRIPTION
Enables the use of `group-focus-visible-within` and `peer-focus-visible-within`